### PR TITLE
Reuse the parts in the message body

### DIFF
--- a/Mail/Template/TransportBuilder.php
+++ b/Mail/Template/TransportBuilder.php
@@ -107,27 +107,8 @@ class TransportBuilder extends \Magento\Framework\Mail\Template\TransportBuilder
             // @see https://magento.stackexchange.com/questions/292760/unable-to-add-attachment-in-email-after-upgrade-to-magento-2-3-3-version
 
             $mimeMessage = $this->mimeMessageFactory->create();
-            /** @var Part $bodyPart */
-            $bodyPart = $this->partFactory->create(['content' => $this->message->getBody()]);
-            // Cannot inherit through $this->message. Default is utf-8.
-            $bodyPart->setCharset('utf-8');
-
-            // Re-used from prepare message, can be removed in 2.3.3.
-            // Because they are using parts by default. These interface type logic can be removed.
-            $template = $this->getTemplate();
-            switch ($template->getType()) {
-                case TemplateTypesInterface::TYPE_TEXT:
-                    $bodyPart->setType(Mime::TYPE_TEXT);
-                    $mimeMessage->setParts(array_merge([$bodyPart], $this->attachments));
-                    $this->message->setBodyText($mimeMessage);
-                    break;
-
-                case TemplateTypesInterface::TYPE_HTML:
-                    $bodyPart->setType(Mime::TYPE_HTML);
-                    $mimeMessage->setParts(array_merge([$bodyPart], $this->attachments));
-                    $this->message->setBodyHtml($mimeMessage);
-                    break;
-            }
+            $mimeMessage->setParts(array_merge($this->message->getBody()->getParts(), $this->attachments));
+            $this->message->setBody($mimeMessage);
         }
     }
 

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,9 @@
     ],
     "license": "MIT",
     "minimum-stability": "stable",
+    "require": {
+        "magento/framework": ">=102.0.0 <102.0.3"
+    },
     "autoload": {
         "psr-4": {
             "WeProvide\\MailAttachment\\": ""


### PR DESCRIPTION
Using `$this->message->getBody()` as content for the new part was causing "Content must be string or resource; received "Zend_Mime_Part"" when trying to send an e-mail with an attachment.

I chose to reuse the parts already defined in `$this->message->getBody()` and merge those with the attachment parts.